### PR TITLE
Implement horizontal mobile carousel for service cards

### DIFF
--- a/agroconsultora-cerezas/css/estilos.css
+++ b/agroconsultora-cerezas/css/estilos.css
@@ -455,7 +455,6 @@ footer a[aria-label] {
 
 /* -------------------- RESPONSIVE ------------------- */
 @media (max-width: 950px) {
-  .servicios-cards,
   .diferenciadores,
   .logos-clientes,
   .blog-cards {
@@ -497,6 +496,22 @@ footer a[aria-label] {
   }
   .footer-container {
     padding: 0 2vw;
+  }
+}
+
+@media (max-width: 800px) {
+  .servicios-cards.carousel {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x mandatory;
+    gap: 1rem;
+    padding-bottom: 1rem;
+  }
+  .servicios-cards.carousel .card {
+    flex: 0 0 80%;
+    max-width: 80%;
+    scroll-snap-align: center;
   }
 }
 

--- a/agroconsultora-cerezas/index-en.html
+++ b/agroconsultora-cerezas/index-en.html
@@ -54,7 +54,7 @@
   <!-- SERVICES HIGHLIGHTS -->
   <section class="servicios-destacados fade-in">
     <h2>Services for Growers & Exporters</h2>
-    <div class="servicios-cards">
+    <div class="servicios-cards carousel">
       <div class="card">
         <img src="assets/icons/consultoria.svg" alt="Agricultural Consulting" loading="lazy">
         <h3>Comprehensive Technical Consulting</h3>

--- a/agroconsultora-cerezas/index.html
+++ b/agroconsultora-cerezas/index.html
@@ -66,7 +66,7 @@
   <!-- SERVICIOS DESTACADOS -->
   <section class="servicios-destacados fade-in">
     <h2>Servicios para Productores & Exportadores</h2>
-    <div class="servicios-cards">
+    <div class="servicios-cards carousel">
       <div class="card">
         <img src="assets/icons/consultoria.svg" alt="Asesoría agrícola" loading="lazy">
         <h3>Asesoría Técnica Integral</h3>

--- a/agroconsultora-cerezas/js/main.js
+++ b/agroconsultora-cerezas/js/main.js
@@ -9,24 +9,49 @@ document.addEventListener('DOMContentLoaded', () => {
   const blurBg = document.getElementById('menu-blur-bg');
   const body = document.body;
 
-  if (!hamburger || !menu) return;
+  if (hamburger && menu) {
+    function toggleMenu() {
+      hamburger.classList.toggle('active');
+      menu.classList.toggle('open');
+      body.classList.toggle('menu-open');
+      if (blurBg) blurBg.classList.toggle('open');
+    }
 
-  function toggleMenu() {
-    hamburger.classList.toggle('active');
-    menu.classList.toggle('open');
-    body.classList.toggle('menu-open');
-    if (blurBg) blurBg.classList.toggle('open');
+    hamburger.addEventListener('click', toggleMenu);
+
+    // Cierra el menú al hacer clic en el fondo borroso
+    if (blurBg) blurBg.addEventListener('click', toggleMenu);
+
+    // Cierra el menú al seleccionar un enlace de navegación
+    menu.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        if (menu.classList.contains('open')) toggleMenu();
+      });
+    });
   }
 
-  hamburger.addEventListener('click', toggleMenu);
+  // Carrusel auto deslizante para tarjetas de servicios en móvil
+  const scroller = document.querySelector('.servicios-cards.carousel');
+  if (scroller && window.matchMedia('(max-width: 800px)').matches) {
+    scroller.scrollLeft = 0;
+    let rafId;
+    const speed = 0.5; // píxeles por frame
 
-  // Cierra el menú al hacer clic en el fondo borroso
-  if (blurBg) blurBg.addEventListener('click', toggleMenu);
+    const step = () => {
+      scroller.scrollLeft += speed;
+      if (scroller.scrollLeft >= scroller.scrollWidth - scroller.clientWidth) {
+        scroller.scrollLeft = 0;
+      }
+      rafId = requestAnimationFrame(step);
+    };
 
-  // Cierra el menú al seleccionar un enlace de navegación
-  menu.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
-      if (menu.classList.contains('open')) toggleMenu();
-    });
-  });
+    const start = () => { if (!rafId) rafId = requestAnimationFrame(step); };
+    const stop = () => { if (rafId) { cancelAnimationFrame(rafId); rafId = null; } };
+
+    scroller.addEventListener('pointerdown', stop, { passive: true });
+    scroller.addEventListener('pointerup', start);
+    scroller.addEventListener('mouseenter', stop);
+    scroller.addEventListener('mouseleave', start);
+    start();
+  }
 });


### PR DESCRIPTION
## Summary
- adjust responsive CSS to support carousel on mobile
- mark homepage service sections with new `carousel` class
- implement auto-scrolling carousel behavior in `main.js`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68844a73df44832292cd41cbe58bbd24